### PR TITLE
Keyboard does not appear on Chrome on Android

### DIFF
--- a/Control.Geocoder.js
+++ b/Control.Geocoder.js
@@ -82,6 +82,8 @@
 				this._expand();
 			}
 
+			L.DomEvent.disableClickPropagation(container);
+
 			return container;
 		},
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,6 +3,8 @@
 <head>
 	<title>Leaflet Control Geocoder</title>
 
+  <meta name='viewport' content='width=device-width, user-scalable=no initial-scale=1, maximum-scale=1'>
+
 	<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.6.4/leaflet.css" />
 	<!--[if lte IE 8]><link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.6.4/leaflet.ie.css" /><![endif]-->
 	<link rel="stylesheet" href="../Control.Geocoder.css" />


### PR DESCRIPTION
I've spent the last few hours in frustration trying to fix this in my own geocoder control plugin https://github.com/Esri/esri-leaflet-geocoder/issues/22 and started looking around to see if other geocoder control plugins have the same problem.

The issue is the soft keyboard will not open up on Chrome for Android even though the control is getting focused.

I'm thinking the same bug if affecting both of our libraries. Interestingly enough it does not seem to affect https://github.com/smeijer/L.GeoSearch. I'm going to keep researching this and see if I can fix it. Do you want me to keep you updated here if I find anything?
