### PR TITLE
Remove explicit size of 'ul.leaflet-control-geocoder-alternatives' to allow automatic size from '.leaflet-control-geocoder-expanded input' size

### DIFF
--- a/Control.Geocoder.css
+++ b/Control.Geocoder.css
@@ -80,7 +80,6 @@
 }
 
 ul.leaflet-control-geocoder-alternatives {
-	width: 260px;
 	overflow: hidden;
   	text-overflow: ellipsis;
   	white-space: nowrap;


### PR DESCRIPTION
Setting a new size to '.leaflet-control-geocoder-expanded input' don't break the display
