### PR TITLE
Adds a bower.json file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,30 @@
+{
+  "name": "leaflet-control-geocoder",
+  "version": "1.0.0",
+  "homepage": "https://github.com/perliedman/leaflet-control-geocoder",
+  "authors": [
+    "Per Liedman <per@liedman.net>"
+  ],
+  "description": "Extendable geocoder with builtin OSM/Nominatim support",
+  "main": "Control.Geocoder.js",
+  "moduleType": [
+    "amd",
+    "globals"
+  ],
+  "keywords": [
+    "leaflet",
+    "geocoder",
+    "nominatim"
+  ],
+  "license": "BSD-2-Clause",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "leaflet": "~0.7.2"
+  }
+}


### PR DESCRIPTION
Here the bower.json file in order to make the 1.0.0 available in the Bower registry.
It is based on the informations found in the package.json file.

Related to issue #27.