### PR TITLE
Added a keep current zoom level option

### DIFF
--- a/Control.Geocoder.js
+++ b/Control.Geocoder.js
@@ -23,7 +23,8 @@
 			expand: 'click',
 			position: 'topright',
 			placeholder: 'Search...',
-			errorMessage: 'Nothing found.'
+			errorMessage: 'Nothing found.',
+			keepCurrentZoomLevel: true
 		},
 
 		_callbackId: 0,
@@ -103,7 +104,12 @@
 		},
 
 		markGeocode: function(result) {
-			this._map.fitBounds(result.bbox);
+			if(this.options.keepCurrentZoomLevel){
+				this._map.panTo(Ember.get(result, 'center'));
+			}
+			else{
+				this._map.fitBounds(result.bbox);
+			}
 
 			if (this._geocodeMarker) {
 				this._map.removeLayer(this._geocodeMarker);


### PR DESCRIPTION
Added a 'keep current zoom level' option that instead of making the map fit bounds to the result's bbox simply pans it to the result's center coordinates
