### PR TITLE
Fix control size

### DIFF
--- a/Control.Geocoder.css
+++ b/Control.Geocoder.css
@@ -30,6 +30,10 @@
 	transition: width 0.125s ease-in;
 }
 
+.leaflet-control-geocoder-form input{
+  padding: 0px;
+}
+
 .leaflet-touch .leaflet-control-geocoder-form input {
 	font-size: 22px;
 }


### PR DESCRIPTION
Fixed the button size so it's the same one other leaflet controllers have and also fixed search box expansion causing the icon and overall component size to increase vertically

Fix for perliedman/leaflet-control-geocoder#45