### PR TITLE
Setting application/json as Accept header on geocode requests

### DIFF
--- a/Control.Geocoder.js
+++ b/Control.Geocoder.js
@@ -251,6 +251,7 @@
 	};
 	L.Control.Geocoder.getJSON = function(url, params, callback) {
 		var xmlHttp = new XMLHttpRequest();
+		xmlHttp.setRequestHeader("Accept", "application/json");
 		xmlHttp.onreadystatechange = function () {
 			if (xmlHttp.readyState != 4){
 				return;

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "leaflet-control-geocoder",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "homepage": "https://github.com/perliedman/leaflet-control-geocoder",
   "authors": [
     "Per Liedman <per@liedman.net>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leaflet-control-geocoder",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Extendable geocoder with builtin OSM/Nominatim support",
   "main": "Control.Geocoder.js",
   "scripts": {


### PR DESCRIPTION
This will ensure that the geocode service used will return the response in json format, since that is what we always expect (doing JSON.parse on the response). 

Chrome adds: 
Accept:*/* 
Which works.

Firefox explicitly adds 
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Based on service impl, HTML instead of JSON is returned.

I've also prepared a new bower version. All you need to do is to push a corresponding tag to it:
git tag -a v1.1.1 -m "[] Version 1.1.1"
git push origin master --tags