### PR TITLE
Improve empty link

### DIFF
--- a/Control.Geocoder.js
+++ b/Control.Geocoder.js
@@ -43,7 +43,7 @@
 			    input;
 
 			icon.innerHTML = '&nbsp;';
-			icon.href = '#';
+			icon.href = 'javascript:void(0);';
 			this._map = map;
 			this._container = container;
 			input = this._input = L.DomUtil.create('input');


### PR DESCRIPTION
`href="#"` is an anti pattern, because it leaves an entry in the browser history and can cause an actual redirect in some configurations (happened on my Ember app). `javascript:void(0);` is safe and has the intended effect.