### PR TITLE
Add specificity to style of search icon

### DIFF
--- a/Control.Geocoder.css
+++ b/Control.Geocoder.css
@@ -1,13 +1,13 @@
 .leaflet-control-geocoder {
 	background: white;
 }
-.leaflet-control-geocoder a {
+.leaflet-control-geocoder .leaflet-control-geocoder-icon {
 	border-bottom-left-radius: 4px;
 	border-bottom-right-radius: 4px;
 	border-bottom: none;
 	display: inline-block;
 }
-.leaflet-control-geocoder a:hover {
+.leaflet-control-geocoder .leaflet-control-geocoder-icon:hover {
 	border-bottom: none;
 	display: inline-block;
 }


### PR DESCRIPTION
If the CSS for this control is loaded before leaflet's CSS, the search icon will take on a style defined in leaflet instead of for the control.

With leaflet CSS loaded first, correct styling is applied:
http://jsfiddle.net/radomtzz/

With this control's CSS loaded first, incorrect styling is applied:
http://jsfiddle.net/2mro7ssq/

By making the rule more specific, the styling is correct no matter whose CSS is loaded first:
http://jsfiddle.net/2mro7ssq/2/