### PR TITLE
removed redundant clickHandler

### DIFF
--- a/Control.Geocoder.js
+++ b/Control.Geocoder.js
@@ -185,7 +185,7 @@
 				a.appendChild(text);
 			}
 
-			L.DomEvent.addListener(a, 'click', clickHandler, this);
+			//L.DomEvent.addListener(a, 'click', clickHandler, this);
 			L.DomEvent.addListener(li, 'click', clickHandler, this);
 
 			return li;


### PR DESCRIPTION
The clickHandler was added to both the A and the underlying LI element. Clicking would propagate downward (even though it shouldn't) causing the result-click to happen twice. This can be demonstrated by a simple console.log() in your markGeocode() method.