### PR TITLE
Options for Google Geocoder, address_components from its result

### DIFF
--- a/Control.Geocoder.js
+++ b/Control.Geocoder.js
@@ -747,8 +747,9 @@
 			service_url: 'https://maps.googleapis.com/maps/api/geocode/json'
 		},
 
-		initialize: function(key) {
+		initialize: function(key, options) {
 				this._key = key;
+				this._options = options;
 		},
 
 		geocode: function(query, cb, context) {
@@ -759,6 +760,7 @@
 			{
 				params['key'] = this._key
 			}
+			params = L.Util.extend(params, this._options);
 
 			L.Control.Geocoder.getJSON(this.options.service_url, params, function(data) {
 					var results = [],
@@ -773,7 +775,8 @@
 							results[i] = {
 									name: loc.formatted_address,
 									bbox: latLngBounds,
-									center: latLng
+									center: latLng,
+									address_components: loc.address_components
 							};
 						}
 					}


### PR DESCRIPTION
* Allow additional `options` for `Google` geocoder, which will be passed
  URL encoded to the `params` of the request.  This can be used to set
  boundaries, for example:

      var googleGeocoder = new L.Control.Geocoder.Google(null, {
        bounds: '40.49,-74.27|40.87,-73.68'
      }),

* Copy in the `address_components` details from Google's geocoder into
  results, as they contain useful data.  For example:

      geocoder.markGeocode = function (result) {
        // Congrats, you have access to houseNumber, street, and county in `result`
        var houseNumber = loc.address_components[0].short_name,
            street = loc.address_components[1].short_name,
            county = loc.address_components[4].short_name;
      };