### PR TITLE
Fix the Mapzen factory function to propagate the API key

### DIFF
--- a/src/geocoders/mapzen.js
+++ b/src/geocoders/mapzen.js
@@ -68,7 +68,7 @@ module.exports = {
 		}
 	}),
 
-	factory: function(options) {
-		return new L.Control.Geocoder.Mapzen(options);
+	factory: function(apiKey, options) {
+		return new L.Control.Geocoder.Mapzen(apiKey, options);
 	}
 };


### PR DESCRIPTION
You can tell I was doing `new L.Control.Geocoder.Mapzen` rather than using the factory function when I was testing this last night...