### PR TITLE
Added support for the unofficial api for BA Como Llego

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The plugin supports many different data providers:
 * [What3Words](http://http://what3words.com/)
 * [Photon](http://photon.komoot.de/)
 * [Mapzen Search](https://mapzen.com/projects/search)
+* [BA Como Viajo](https://mapa.buenosaires.gob.ar/comollego/)
 
 The plugin can easily be extended to support other providers.
 
@@ -152,7 +153,7 @@ An object that represents a result from a geocoding query.
 | Property   | Type             | Description                           |
 | ---------- | ---------------- | ------------------------------------- |
 | name       | String           | Name of found location                |
-| bounds     | L.LatLngBounds   | The bounds of the location            |
+| bbox       | L.LatLngBounds   | The bounds of the location            |
 | center     | L.LatLng         | The center coordinate of the location |
 | icon       | String           | URL for icon representing result; optional |
 | html       | String           | (optional) HTML formatted representation of the name |

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "leaflet": "global:L"
   },
   "dependencies": {
-    "leaflet": "~0.7.3"
+    "leaflet": "~0.7.3",
+    "proj4": "2.3.12"
   },
   "devDependencies": {
     "browserify": "^11.0.1",

--- a/src/geocoders/bacomollego.js
+++ b/src/geocoders/bacomollego.js
@@ -130,7 +130,7 @@ module.exports = {
 	}),
 
 	factory: function(options) {
-		return new L.Control.Geocoder.BAComoviajo(options);
+		return new L.Control.Geocoder.BAComoLlego(options);
 	}
 };
 

--- a/src/geocoders/bacomoviajo.js
+++ b/src/geocoders/bacomoviajo.js
@@ -1,0 +1,135 @@
+var L = require('leaflet'),
+	Util = require('../util'),
+	proj4 = require('proj4');
+
+module.exports = {
+	class: L.Class.extend({
+		options: {
+			tmerc: new proj4.Proj("+proj=tmerc +lat_0=-34.629269 +lon_0=-58.463300 +k=0.999998 +x_0=100000 +y_0=100085 +ellps=intl +units=m +no_defs"),
+			wsg: new proj4.Proj("EPSG:4326"),
+			geocodeUrl: 'https://ws.usig.buenosaires.gob.ar/geocoder/2.2/geocoding/',
+			reverseUrl: 'https://ws.usig.buenosaires.gob.ar/geocoder/2.2/reversegeocoding/',
+			normalizarUrl: 'https://servicios.usig.buenosaires.gob.ar/normalizar',
+			timeout: 10000,
+			maxOptions: 3
+		},
+
+		initialize: function(options) {
+			L.setOptions(this, options);
+		},
+
+		_normalizar: function(query, cb, context){
+			Util.jsonp(this.options.normalizarUrl, {
+				maxOptions: this.options.maxOptions,
+				direccion: query
+			}, function(json){
+				cb.call(context, json);
+			}, this, "callback");
+			return this;
+		},
+
+		_tmerc2LatLng: function(a){
+			var b = proj4.toPoint(a);
+			return proj4.transform(this.options.tmerc, this.options.wsg, b),
+			[ b.y, b.x ];
+		},
+
+		geocode: function(query, cb, context) {
+			var results = [],
+				maxOptions = 0,
+				timedOut = false,
+				timer;
+
+			function checkIfCb(){
+				if(!timedOut && results.length >= maxOptions){
+					timedOut = true;
+					cb.call(context || cb, results);
+					clearTimeout(timer);
+				}
+			}
+
+			function pushAndCb(c){
+				results.push(c);
+				checkIfCb();
+			}
+
+			this._normalizar(query, function(json){
+				timer = setTimeout(L.bind(function(){
+					timedOut = true;
+					cb.call(context || cb, results);
+				}, this), this.options.timeout);
+
+				maxOptions = json.direccionesNormalizadas.length;
+
+				json.direccionesNormalizadas.forEach(function(e){
+					if(e.coordenadas){
+						var center = L.latLng(e.coordenadas.y, e.coordenadas.x);
+						pushAndCb({
+							bbox: L.latLngBounds(center, center),
+							name: e.direccion,
+							center: center
+						});
+					}else if([
+							(e.nombre_localidad||"").toUpperCase(),
+							(e.nombre_partido||"").toUpperCase(),
+					].indexOf("CABA") > -1)
+						L.bind(function(e){
+							Util.jsonp(this.options.geocodeUrl, {
+								cod_calle: e.cod_calle,
+								altura: e.altura
+							}, function(tmerc){
+								if(typeof(tmerc.x) != "undefined" && typeof(tmerc.y) != "undefined"){
+									var center = L.latLng.apply(L, this._tmerc2LatLng([tmerc.x, tmerc.y]));
+									pushAndCb({
+										bbox: L.latLngBounds(center, center),
+										name: e.direccion,
+										center: center
+									});
+								}else{
+									maxOptions--;
+									checkIfCb();
+								}
+							}, this, "callback");
+						}, this)(e);
+					else
+						this._normalizar(e.direccion, function(json){
+							var data = json.direccionesNormalizadas[0];
+							if(data && data.coordenadas){
+								var center = L.latLng(data.coordenadas.y, data.coordenadas.x);
+								pushAndCb({
+									bbox: L.latLngBounds(center, center),
+									name: data.direccion,
+									center: center
+								});
+							} else{
+								maxOptions--;
+								checkIfCb();
+							}
+						}, this);
+				}, this);
+			}, this);
+		},
+
+		suggest: function(query, cb, context) {
+			return this.geocode(query, cb, context);
+		},
+
+		reverse: function(location, scale, cb, context) {
+			Util.jsonp(this.options.reverseUrl, {
+				x: location.lng,
+				y: location.lat,
+			}, function(json){
+				var results = [{
+					bbox: L.latLngBounds(location, location),
+					name: json.puerta,
+					center: location
+				}];
+			}, "callback");
+		}
+	}),
+
+	factory: function(options) {
+		return new L.Control.Geocoder.BAComoviajo(options);
+	}
+};
+

--- a/src/geocoders/bacomoviajo.js
+++ b/src/geocoders/bacomoviajo.js
@@ -124,6 +124,7 @@ module.exports = {
 					name: json.puerta,
 					center: location
 				}];
+				cb.call(context || cb, results);
 			}, "callback");
 		}
 	}),

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ var L = require('leaflet'),
 	Google = require('./geocoders/google'),
 	Photon = require('./geocoders/photon'),
 	Mapzen = require('./geocoders/mapzen');
+	BAComoviajo = require('./geocoders/bacomoviajo');
 
 module.exports = L.Util.extend(Control.class, {
 	Nominatim: Nominatim.class,
@@ -25,7 +26,9 @@ module.exports = L.Util.extend(Control.class, {
 	Photon: Photon.class,
 	photon: Photon.factory,
 	Mapzen: Mapzen.class,
-	mapzen: Mapzen.factory
+	mapzen: Mapzen.factory,
+	BAComoviajo: BAComoviajo.class,
+	bacomoviajo: BAComoviajo.factory
 });
 
 L.Util.extend(L.Control, {

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ var L = require('leaflet'),
 	Google = require('./geocoders/google'),
 	Photon = require('./geocoders/photon'),
 	Mapzen = require('./geocoders/mapzen');
-	BAComoviajo = require('./geocoders/bacomoviajo');
+	BAComoLlego = require('./geocoders/bacomollego');
 
 module.exports = L.Util.extend(Control.class, {
 	Nominatim: Nominatim.class,
@@ -27,8 +27,8 @@ module.exports = L.Util.extend(Control.class, {
 	photon: Photon.factory,
 	Mapzen: Mapzen.class,
 	mapzen: Mapzen.factory,
-	BAComoviajo: BAComoviajo.class,
-	bacomoviajo: BAComoviajo.factory
+	BAComoLlego: BAComoLlego.class,
+	bacomollego: BAComoLlego.factory
 });
 
 L.Util.extend(L.Control, {


### PR DESCRIPTION
The government of the city of Buenos Aires *(Argentina)* has a forward and inverse geocoder for the [BA Como LLego App](https://mapa.buenosaires.gob.ar/comollego/). This api only works for places that are in the [**AMBA** *(Area Metropolitana Buenos Aires)*](https://en.wikipedia.org/wiki/Greater_Buenos_Aires)

This PR adds the posibility of using this api. It isn't officially documentated, but i've writting my researchs [here](https://github.com/NickCis/lrm-bacomollego/wiki).