### PR TITLE
Bump leaflet version in npm dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "leaflet": "global:L"
   },
   "dependencies": {
-    "leaflet": "~0.7.7"
+    "leaflet": "^1.0.0"
   },
   "devDependencies": {
     "browserify": "^11.0.1",


### PR DESCRIPTION
Leaflet v1.0.0 being out (and advertised as supported as of https://github.com/perliedman/leaflet-control-geocoder/commit/a65818b0b9bfa27edeea648070bc1a6d262f0ea3), the installation process could default to use it over v0.7.7.

A new npm release of `leaflet-control-geocoder` including this change would hopefully solve dependencies troubles like those described in #143.

Not sure if there are any downsides to this you might already have considered?