### PR TITLE
Add html template option for photon

### DIFF
--- a/src/geocoders/photon.js
+++ b/src/geocoders/photon.js
@@ -71,6 +71,9 @@ module.exports = {
 
 					results.push({
 						name: this._deocodeFeatureName(f),
+						html: this.options.htmlTemplate ?
+							this.options.htmlTemplate(f)
+							: undefined,
 						center: latLng,
 						bbox: bbox,
 						properties: f.properties


### PR DESCRIPTION
When only using the 'name' property is Photon search results, many records appear to be duplicates. The records have the same name, and can only be distinguished by including other properties (country, OSM type etc.,) This adds the html template option to the Photon Geocoder, so extra fields can be configured & formatted.
