### PR TITLE
Doc(README): fix event.geocode.bbox property API

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ An object that represents a result from a geocoding query.
 | Property   | Type             | Description                           |
 | ---------- | ---------------- | ------------------------------------- |
 | name       | String           | Name of found location                |
-| bounds     | L.LatLngBounds   | The bounds of the location            |
+| bbox       | L.LatLngBounds   | The bounds of the location            |
 | center     | L.LatLng         | The center coordinate of the location |
 | icon       | String           | URL for icon representing result; optional |
 | html       | String           | (optional) HTML formatted representation of the name |


### PR DESCRIPTION
The `event.geocode` object that is passed to the `"markgeocode"` event listener does not have a `bounds` property, but a `bbox` one instead.

See for example the Nominatim adapter:
https://github.com/perliedman/leaflet-control-geocoder/blob/master/src/geocoders/nominatim.js#L53
(same for other adapters)

Corrected the README accordingly.