### PR TITLE
Adding ability to pass query options to the Mapbox API

### DIFF
--- a/src/geocoders/mapbox.js
+++ b/src/geocoders/mapbox.js
@@ -5,24 +5,25 @@ module.exports = {
 	class: L.Class.extend({
 		options: {
 			serviceUrl: 'https://api.tiles.mapbox.com/v4/geocode/mapbox.places-v1/',
-			geocodingQueryParams: {}
+			geocodingQueryParams: {},
+			reverseQueryParams: {}
 		},
 
 		initialize: function(accessToken, options) {
-			var params = options.geocodingQueryParams;
-			params.access_token = accessToken;
+			L.setOptions(this, options);
+			this.options.geocodingQueryParams.access_token = accessToken;
+			this.options.reverseQueryParams.access_token = accessToken;
+		},
+
+		geocode: function(query, cb, context) {
+			var params = this.options.geocodingQueryParams;
 			if (typeof params.proximity !== 'undefined'
 				&& params.proximity.hasOwnProperty('lat')
 				&& params.proximity.hasOwnProperty('lng'))
 			{
 				params.proximity = params.proximity.lng + ',' + params.proximity.lat;
 			}
-			options.geocodingQueryParams = params;
-			L.setOptions(this, options);
-		},
-
-		geocode: function(query, cb, context) {
-			Util.getJSON(this.options.serviceUrl + encodeURIComponent(query) + '.json', this.options.geocodingQueryParams, function(data) {
+			Util.getJSON(this.options.serviceUrl + encodeURIComponent(query) + '.json', params, function(data) {
 				var results = [],
 				loc,
 				latLng,
@@ -56,7 +57,7 @@ module.exports = {
 		},
 
 		reverse: function(location, scale, cb, context) {
-			Util.getJSON(this.options.serviceUrl + encodeURIComponent(location.lng) + ',' + encodeURIComponent(location.lat) + '.json', this.options.geocodingQueryParams, function(data) {
+			Util.getJSON(this.options.serviceUrl + encodeURIComponent(location.lng) + ',' + encodeURIComponent(location.lat) + '.json', this.options.reverseQueryParams, function(data) {
 				var results = [],
 				loc,
 				latLng,

--- a/src/geocoders/mapbox.js
+++ b/src/geocoders/mapbox.js
@@ -4,18 +4,22 @@ var L = require('leaflet'),
 module.exports = {
 	class: L.Class.extend({
 		options: {
-			serviceUrl: 'https://api.tiles.mapbox.com/v4/geocode/mapbox.places-v1/'
+			serviceUrl: 'https://api.tiles.mapbox.com/v4/geocode/mapbox.places-v1/',
+			geocodingQueryParams: {}
 		},
 
 		initialize: function(accessToken, options) {
+			var params = options.geocodingQueryParams;
+			params.access_token = accessToken;
+			if (params.proximity.hasOwnProperty('lat') && params.proximity.hasOwnProperty('lng')) {
+				params.proximity = params.proximity.lng + ',' + params.proximity.lat;
+			}
+			options.geocodingQueryParams = params;
 			L.setOptions(this, options);
-			this._accessToken = accessToken;
 		},
 
 		geocode: function(query, cb, context) {
-			Util.getJSON(this.options.serviceUrl + encodeURIComponent(query) + '.json', {
-				access_token: this._accessToken,
-			}, function(data) {
+			Util.getJSON(this.options.serviceUrl + encodeURIComponent(query) + '.json', this.options.geocodingQueryParams, function(data) {
 				var results = [],
 				loc,
 				latLng,
@@ -24,7 +28,7 @@ module.exports = {
 					for (var i = 0; i <= data.features.length - 1; i++) {
 						loc = data.features[i];
 						latLng = L.latLng(loc.center.reverse());
-						if(loc.hasOwnProperty('bbox'))
+						if (loc.hasOwnProperty('bbox'))
 						{
 							latLngBounds = L.latLngBounds(L.latLng(loc.bbox.slice(0, 2).reverse()), L.latLng(loc.bbox.slice(2, 4).reverse()));
 						}
@@ -49,9 +53,7 @@ module.exports = {
 		},
 
 		reverse: function(location, scale, cb, context) {
-			Util.getJSON(this.options.serviceUrl + encodeURIComponent(location.lng) + ',' + encodeURIComponent(location.lat) + '.json', {
-				access_token: this._accessToken,
-			}, function(data) {
+			Util.getJSON(this.options.serviceUrl + encodeURIComponent(location.lng) + ',' + encodeURIComponent(location.lat) + '.json', this.options.geocodingQueryParams, function(data) {
 				var results = [],
 				loc,
 				latLng,
@@ -60,7 +62,7 @@ module.exports = {
 					for (var i = 0; i <= data.features.length - 1; i++) {
 						loc = data.features[i];
 						latLng = L.latLng(loc.center.reverse());
-						if(loc.hasOwnProperty('bbox'))
+						if (loc.hasOwnProperty('bbox'))
 						{
 							latLngBounds = L.latLngBounds(L.latLng(loc.bbox.slice(0, 2).reverse()), L.latLng(loc.bbox.slice(2, 4).reverse()));
 						}

--- a/src/geocoders/mapbox.js
+++ b/src/geocoders/mapbox.js
@@ -11,7 +11,10 @@ module.exports = {
 		initialize: function(accessToken, options) {
 			var params = options.geocodingQueryParams;
 			params.access_token = accessToken;
-			if (params.proximity.hasOwnProperty('lat') && params.proximity.hasOwnProperty('lng')) {
+			if (typeof params.proximity !== 'undefined'
+				&& params.proximity.hasOwnProperty('lat')
+				&& params.proximity.hasOwnProperty('lng'))
+			{
 				params.proximity = params.proximity.lng + ',' + params.proximity.lat;
 			}
 			options.geocodingQueryParams = params;


### PR DESCRIPTION
This is a fairly simple change to pass along options to the Mapbox API. All options that are set are passed directly to the API, except for the `proximity` option which will also accept L.latLng objects. This allows you to do something like:

```
Geocoder.mapbox('pk.blahblahblah', { geocodingQueryParams: {
    country: 'US',
    proximity: map.getCenter()
}})
```