### PR TITLE
Mobile experience improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ L.Control.Geocoder(options)
 | Option          |  Type            |  Default          | Description |
 | --------------- | ---------------- | ----------------- | ----------- |
 | collapsed       |  Boolean         |  true             | Collapse control unless hovered/clicked |
+| expand          |  String          |  "touch"          | How to expand a collapsed control: `touch` `click` `hover` |
 | position        |  String          |  "topright"       | Control [position](http://leafletjs.com/reference.html#control-positions) |
 | placeholder     |  String          |  "Search..."      | Placeholder text for text input
 | errorMessage    |  String          |  "Nothing found." | Message when no result found / geocoding error occurs |

--- a/src/control.js
+++ b/src/control.js
@@ -68,30 +68,30 @@ module.exports = {
 						}
 					}, this);
 				}
-                else if (L.Browser.touch && this.options.expand === 'touch') {
-                    L.DomEvent.addListener(icon, 'touchstart', function(e) {
-                        this._toggle();
-                        e.preventDefault(); // mobile: clicking focuses the icon, so UI expands and immediately collapses
-                        e.stopPropagation();
-                    }, this);
-                }
-                else {
+				else if (L.Browser.touch && this.options.expand === 'touch') {
+					L.DomEvent.addListener(icon, 'touchstart', function(e) {
+						this._toggle();
+						e.preventDefault(); // mobile: clicking focuses the icon, so UI expands and immediately collapses
+						e.stopPropagation();
+					}, this);
+				}
+				else {
 					L.DomEvent.addListener(icon, 'mouseover', this._expand, this);
 					L.DomEvent.addListener(icon, 'mouseout', this._collapse, this);
 					this._map.on('movestart', this._collapse, this);
 				}
 			} else {
-                this._expand();
-                if (L.Browser.touch) {
-                    L.DomEvent.addListener(icon, 'touchstart', function(e) {
-                        this._geocode(e);
-                    }, this);
-                }
-                else {
-                    L.DomEvent.addListener(icon, 'click', function(e) {
-                        this._geocode(e);
-                    }, this);
-                }
+				this._expand();
+				if (L.Browser.touch) {
+					L.DomEvent.addListener(icon, 'touchstart', function(e) {
+						this._geocode(e);
+					}, this);
+				}
+				else {
+					L.DomEvent.addListener(icon, 'click', function(e) {
+						this._geocode(e);
+					}, this);
+				}
 			}
 
 			if (this.options.defaultMarkGeocode) {
@@ -166,7 +166,6 @@ module.exports = {
 			if (!this.options.collapsed) {
 				this._clearResults();
 			}
-
 			this.fire('markgeocode', {geocode: result});
 		},
 
@@ -185,10 +184,10 @@ module.exports = {
 		},
 
 		_collapse: function () {
-            L.DomUtil.removeClass(this._container, 'leaflet-control-geocoder-expanded');
+			L.DomUtil.removeClass(this._container, 'leaflet-control-geocoder-expanded');
 			L.DomUtil.addClass(this._alts, 'leaflet-control-geocoder-alternatives-minimized');
 			L.DomUtil.removeClass(this._errorElement, 'leaflet-control-geocoder-error');
-            this._input.blur(); // mobile: keyboard shouldn't stay expanded
+			this._input.blur(); // mobile: keyboard shouldn't stay expanded
 			this.fire('collapse');
 		},
 
@@ -201,21 +200,21 @@ module.exports = {
 		_createAlt: function(result, index) {
 			var li = L.DomUtil.create('li', ''),
 				a = L.DomUtil.create('a', '', li),
-			    icon = this.options.showResultIcons && result.icon ? L.DomUtil.create('img', '', a) : null,
-			    text = result.html ? undefined : document.createTextNode(result.name),
-			    mouseDownHandler = function mouseDownHandler(e) {
-			    	// In some browsers, a click will fire on the map if the control is
-			    	// collapsed directly after mousedown. To work around this, we
-			    	// wait until the click is completed, and _then_ collapse the
-			    	// control. Messy, but this is the workaround I could come up with
-			    	// for #142.
-			    	this._preventBlurCollapse = true;
+				icon = this.options.showResultIcons && result.icon ? L.DomUtil.create('img', '', a) : null,
+				text = result.html ? undefined : document.createTextNode(result.name),
+				mouseDownHandler = function mouseDownHandler(e) {
+					// In some browsers, a click will fire on the map if the control is
+					// collapsed directly after mousedown. To work around this, we
+					// wait until the click is completed, and _then_ collapse the
+					// control. Messy, but this is the workaround I could come up with
+					// for #142.
+					this._preventBlurCollapse = true;
 					L.DomEvent.stop(e);
 					this._geocodeResultSelected(result);
 					L.DomEvent.on(li, 'click', function() {
-			    		if (this.options.collapsed) {
-			    			this._collapse();
-			    		}
+						if (this.options.collapsed) {
+							this._collapse();
+						}
 					}, this);
 				};
 

--- a/src/control.js
+++ b/src/control.js
@@ -6,7 +6,7 @@ module.exports = {
 		options: {
 			showResultIcons: false,
 			collapsed: true,
-			expand: 'click',
+			expand: 'touch', // options: touch, click, anythingelse
 			position: 'topright',
 			placeholder: 'Search...',
 			errorMessage: 'Nothing found.',


### PR DESCRIPTION
This PR improves the behavior of leaflet-control-geocoder on mobile. Testing is on iOS using iPhone 6 and iPad 2nd-gen.

* `options.expand` supports a new value: `touch` This will use *touchstart* instead of *click* for a faster response when trying to expand the control from a collapsed state.
  * This is a new option, and not a coded-in behavior of `expand: 'click'` if L.Browser.touch is detected. Could go either way; adding a new option seemed best for compatibility and fewest question marks.
  * Interesting note: On iOS, the touchstart needs to be stopped or else it triggers the icon to become focused. By defocusing the input, the UI immediately collapses...

* `_collapse()` adds a `_input.blur()` so that on mobile the keyboard will be dismissed.

* Tapping the icon when `collapse: false` was given, now uses `touchstart` if L.browser.touch was selected, so the geocoding happens with less delay.

* Some trivial cleanups to the className editing code, to use L.DomUtil.removeClass and L.DomUtil.hasClass in a few spots.
