### PR TITLE
Inherit from 'L.Evented' instead of deprecated 'L.Mixin.Events'

### DIFF
--- a/src/control.js
+++ b/src/control.js
@@ -15,7 +15,7 @@ module.exports = {
 			defaultMarkGeocode: true
 		},
 
-		includes: L.Mixin.Events,
+		includes: L.Evented.prototype || L.Mixin.Events,
 
 		initialize: function (options) {
 			L.Util.setOptions(this, options);


### PR DESCRIPTION
Fixes the issue mentioned in https://github.com/perliedman/leaflet-control-geocoder/issues/168. No new tests are required.