### PR TITLE
[fix] pin dropped when result clicked with collapsed false

### DIFF
--- a/src/control.js
+++ b/src/control.js
@@ -166,9 +166,6 @@ module.exports = {
 		},
 
 		_geocodeResultSelected: function(result) {
-			if (!this.options.collapsed) {
-				this._clearResults();
-			}
 			this.fire('markgeocode', {geocode: result});
 		},
 
@@ -217,6 +214,8 @@ module.exports = {
 					L.DomEvent.on(li, 'click', function() {
 						if (this.options.collapsed) {
 							this._collapse();
+						} else {
+							this._clearResults();
 						}
 					}, this);
 				};


### PR DESCRIPTION
Picks up where #142 left off. Takes the other half of the `collapsed` check that was left behind in `_geocodeResultSelected` and also moves it into the `click` handler that's created in the `mouseDownHandler`.