### PR TITLE
Fix this.options.geocoder[mode] is not a function

### DIFF
--- a/src/control.js
+++ b/src/control.js
@@ -87,12 +87,12 @@ module.exports = {
 				this._expand();
 				if (L.Browser.touch) {
 					L.DomEvent.addListener(container, 'touchstart', function(e) {
-						this._geocode(e);
+						this._geocode();
 					}, this);
 				}
 				else {
 					L.DomEvent.addListener(container, 'click', function(e) {
-						this._geocode(e);
+						this._geocode();
 					}, this);
 				}
 			}


### PR DESCRIPTION
Fixes #157. This is based on the comment https://github.com/perliedman/leaflet-control-geocoder/issues/157#issuecomment-268798493.