### PR TITLE
Use ES6 modules, use rollup for module bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/Control.Geocoder.js",
   "scripts": {
     "prepare": "npm run build",
-    "build": "rollup --output.format=iife --name=L.Control.Geocoder --globals=leaflet:L src/index.js --output.file=dist/Control.Geocoder.js",
+    "build": "rollup --output.format=iife --name=L.Control.Geocoder --globals=leaflet:L src/index.js --output.file=dist/Control.Geocoder.js && cpr Control.Geocoder.css dist/ --overwrite && cpr images/ dist/ --overwrite",
     "publish": "sh ./scripts/publish.sh",
     "postpublish": "sh ./scripts/postpublish.sh"
   },
@@ -37,6 +37,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "cpr": "^3.0.1",
     "rollup": "^0.53.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Extendable geocoder with builtin support for Nominatim, Bing, Google, Mapbox, Photon, What3Words, MapQuest, Mapzen, HERE",
   "main": "dist/Control.Geocoder.js",
   "scripts": {
-    "prepare": "sh ./scripts/build.sh",
+    "prepare": "npm run build",
+    "build": "rollup --output.format=iife --name=L.Control.Geocoder --globals=leaflet:L src/index.js --output.file=dist/Control.Geocoder.js",
     "publish": "sh ./scripts/publish.sh",
     "postpublish": "sh ./scripts/postpublish.sh"
   },
@@ -36,9 +37,6 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "browserify": "^11.0.1",
-    "browserify-shim": "^3.8.10",
-    "derequire": "^2.0.3",
-    "es3ify": "^0.1.4"
+    "rollup": "^0.53.2"
   }
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-mkdir -p dist
-
-browserify src/index.js -t browserify-shim -t es3ify --standalone leaflet-control-geocoder | derequire >dist/Control.Geocoder.js
-cp -a Control.Geocoder.css images/ dist/
-
-#browserify test/browserify.js -o test/bundle.js

--- a/src/control.js
+++ b/src/control.js
@@ -1,7 +1,7 @@
-var L = require('leaflet'),
-	Nominatim = require('./geocoders/nominatim').class;
+import L from 'leaflet';
+import Nominatim from './geocoders/nominatim';
 
-module.exports = {
+export default {
 	class: L.Control.extend({
 		options: {
 			showResultIcons: false,
@@ -20,7 +20,7 @@ module.exports = {
 		initialize: function (options) {
 			L.Util.setOptions(this, options);
 			if (!this.options.geocoder) {
-				this.options.geocoder = new Nominatim();
+				this.options.geocoder = new Nominatim.class();
 			}
 
 			this._requestCount = 0;

--- a/src/geocoders/arcgis.js
+++ b/src/geocoders/arcgis.js
@@ -1,7 +1,7 @@
-var L = require('leaflet'),
-	Util = require('../util');
+import L from 'leaflet';
+import Util from '../util';
 
-module.exports = {
+export default {
 	class: L.Class.extend({
 		options: {
 			service_url: 'http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer'

--- a/src/geocoders/bing.js
+++ b/src/geocoders/bing.js
@@ -1,7 +1,7 @@
-var L = require('leaflet'),
-	Util = require('../util');
+import L from 'leaflet';
+import Util from '../util';
 
-module.exports = {
+export default {
 	class: L.Class.extend({
 		initialize: function(key) {
 			this.key = key;

--- a/src/geocoders/google.js
+++ b/src/geocoders/google.js
@@ -1,7 +1,7 @@
-var L = require('leaflet'),
-	Util = require('../util');
+import L from 'leaflet';
+import Util from '../util';
 
-module.exports = {
+export default {
 	class: L.Class.extend({
 		options: {
 			serviceUrl: 'https://maps.googleapis.com/maps/api/geocode/json',

--- a/src/geocoders/here.js
+++ b/src/geocoders/here.js
@@ -1,7 +1,7 @@
-var L = require('leaflet'),
-    Util = require('../util');
+import L from 'leaflet';
+import Util from '../util';
 
-module.exports = {
+export default {
     class: L.Class.extend({
         options: {
             geocodeUrl: 'http://geocoder.api.here.com/6.2/geocode.json',

--- a/src/geocoders/mapbox.js
+++ b/src/geocoders/mapbox.js
@@ -1,7 +1,7 @@
-var L = require('leaflet'),
-	Util = require('../util');
+import L from 'leaflet';
+import Util from '../util';
 
-module.exports = {
+export default {
 	class: L.Class.extend({
 		options: {
 			serviceUrl: 'https://api.tiles.mapbox.com/v4/geocode/mapbox.places-v1/',

--- a/src/geocoders/mapquest.js
+++ b/src/geocoders/mapquest.js
@@ -1,7 +1,7 @@
-var L = require('leaflet'),
-	Util = require('../util');
+import L from 'leaflet';
+import Util from '../util';
 
-module.exports = {
+export default {
 	class: L.Class.extend({
 		options: {
 			serviceUrl: 'https://www.mapquestapi.com/geocoding/v1'

--- a/src/geocoders/mapzen.js
+++ b/src/geocoders/mapzen.js
@@ -1,7 +1,7 @@
-var L = require('leaflet'),
-	Util = require('../util');
+import L from 'leaflet';
+import Util from '../util';
 
-module.exports = {
+export default {
 	class: L.Class.extend({
 		options: {
 			serviceUrl: 'https://search.mapzen.com/v1',

--- a/src/geocoders/nominatim.js
+++ b/src/geocoders/nominatim.js
@@ -1,7 +1,7 @@
-var L = require('leaflet'),
-	Util = require('../util');
+import L from 'leaflet';
+import Util from '../util';
 
-module.exports = {
+export default {
 	class: L.Class.extend({
 		options: {
 			serviceUrl: 'https://nominatim.openstreetmap.org/',

--- a/src/geocoders/photon.js
+++ b/src/geocoders/photon.js
@@ -1,7 +1,7 @@
-var L = require('leaflet'),
-	Util = require('../util');
+import L from 'leaflet';
+import Util from '../util';
 
-module.exports = {
+export default {
 	class: L.Class.extend({
 		options: {
 			serviceUrl: 'https://photon.komoot.de/api/',

--- a/src/geocoders/what3words.js
+++ b/src/geocoders/what3words.js
@@ -1,7 +1,7 @@
-var L = require('leaflet'),
-	Util = require('../util');
+import L from 'leaflet';
+import Util from '../util';
 
-module.exports = {
+export default {
 	class: L.Class.extend({
 		options: {
 			serviceUrl: 'https://api.what3words.com/v2/'

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,17 @@
-var L = require('leaflet'),
-	Control = require('./control'),
-	Nominatim = require('./geocoders/nominatim'),
-	Bing = require('./geocoders/bing'),
-	MapQuest = require('./geocoders/mapquest'),
-	Mapbox = require('./geocoders/mapbox'),
-	What3Words = require('./geocoders/what3words'),
-	Google = require('./geocoders/google'),
-	Photon = require('./geocoders/photon'),
-	Mapzen = require('./geocoders/mapzen'),
-	ArcGis = require('./geocoders/arcgis'),
-	HERE = require('./geocoders/here');
+import L from 'leaflet';
+import Control from './control';
+import Nominatim from './geocoders/nominatim';
+import Bing from './geocoders/bing';
+import MapQuest from './geocoders/mapquest';
+import Mapbox from './geocoders/mapbox';
+import What3Words from './geocoders/what3words';
+import Google from './geocoders/google';
+import Photon from './geocoders/photon';
+import Mapzen from './geocoders/mapzen';
+import ArcGis from './geocoders/arcgis';
+import HERE from './geocoders/here';
 
-module.exports = L.Util.extend(Control.class, {
+var Geocoder = L.Util.extend(Control.class, {
 	Nominatim: Nominatim.class,
 	nominatim: Nominatim.factory,
 	Bing: Bing.class,
@@ -34,7 +34,9 @@ module.exports = L.Util.extend(Control.class, {
 	here: HERE.factory
 });
 
+export default Geocoder;
+
 L.Util.extend(L.Control, {
-	Geocoder: module.exports,
+	Geocoder: Geocoder,
 	geocoder: Control.factory
 });

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,5 @@
-var L = require('leaflet'),
-	lastCallbackId = 0,
+import L from 'leaflet';
+var	lastCallbackId = 0,
 	htmlEscape = (function() {
 		// Adapted from handlebars.js
 		// https://github.com/wycats/handlebars.js/
@@ -37,7 +37,7 @@ var L = require('leaflet'),
 		};
 	})();
 
-module.exports = {
+export default {
 	jsonp: function(url, params, callback, context, jsonpParam) {
 		var callbackId = '_l_geocoder_' + (lastCallbackId++);
 		params[jsonpParam || 'callback'] = callbackId;


### PR DESCRIPTION
https://rollupjs.org/

Rollup has zero overhead for ES6 module imports.

Fixes #124.