### PR TITLE
HERE reverse geocode radius property

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,25 @@ new L.Control.Geocoder.Bing(<String> key)
 L.Control.Geocoder.bing(<String> key)
 ```
 
+## L.Control.Geocoder.HERE
+
+Uses [Here Geocoder API](https://developer.here.com/documentation/geocoder/topics/introduction.html) to respond to geocoding queries. Implements ```IGeocoder```.
+
+Note that you need an API key to use this service.
+
+### Constructor
+
+```ts
+new L.Control.Geocoder.HERE(<String> app_id, <String> app_code, options)
+// or
+L.Control.Geocoder.HERE(<String> app_id, <String> app_code, options)
+```
+## Options
+
+| Option          |  Type            |  Default          | Description |
+| --------------- | ---------------- | ----------------- | ----------- |
+| `reverseQueryParams`       | Object          |  `{ radius: 50 }` | Additional URL parameters (strings) that will be added to reverse geocoding requests. For more information see [Reverse Geocode Resource](https://developer.here.com/documentation/geocoder/topics/resource-reverse-geocode.html) |
+
 ## IGeocoder
 
 An interface implemented to respond to geocoding queries.

--- a/src/geocoders/here.js
+++ b/src/geocoders/here.js
@@ -29,17 +29,28 @@ export default {
     },
 
     reverse: function(location, scale, cb, context) {
-      var params = {
-        prox: encodeURIComponent(location.lat) + ',' + encodeURIComponent(location.lng),
-        mode: 'retrieveAddresses',
-        app_id: this.options.app_id,
-        app_code: this.options.app_code,
-        gen: 9,
-        jsonattributes: 1
-      };
-      params = L.Util.extend(params, this.options.reverseQueryParams);
-      this.getJSON(this.options.reverseGeocodeUrl, params, cb, context);
-    },
+        var radius = this.options.reverseQueryParams.radius || 50;
+        var prox = encodeURIComponent(location.lat) 
+          + ',' + encodeURIComponent(location.lng)
+          + ',' + radius;
+  
+        var params = {
+          prox: prox,
+          mode: 'retrieveAddresses',
+          app_id: this.options.app_id,
+          app_code: this.options.app_code,
+          gen: 9,
+          jsonattributes: 1
+        };
+        params = L.Util.extend(params, this.options.reverseQueryParams);
+  
+        // ommit "radius" in request
+        if (params.hasOwnProperty('radius')) {
+            delete params.radius;
+        }
+  
+        this.getJSON(this.options.reverseGeocodeUrl, params, cb, context);
+      },
 
     getJSON: function(url, params, cb, context) {
       getJSON(url, params, function(data) {


### PR DESCRIPTION
Greetings!

What do you think about adding "radius" property for HERE Reverse geocode? According to [docs](https://developer.here.com/documentation/geocoder/topics/resource-reverse-geocode.html) radius should be sent within "prox" parameter. Without it reverse geocoding works terrible. For example: [with radius](http://reverse.geocoder.api.here.com/6.2/reversegeocode.json?prox=59.962623789375456%2C30.35011231899262%2C50&mode=retrieveAddresses&app_id=LHGn7c1UD8HyjrlRCyYu&app_code=xXX_T0-IGP6ssoK4PLZFZg&gen=9&jsonattributes=1) and [without](http://reverse.geocoder.api.here.com/6.2/reversegeocode.json?prox=59.962623789375456%2C30.35011231899262&mode=retrieveAddresses&app_id=LHGn7c1UD8HyjrlRCyYu&app_code=xXX_T0-IGP6ssoK4PLZFZg&gen=9&jsonattributes=1)