### PR TITLE
Photon: fix wrong building of reverse query params

### DIFF
--- a/src/geocoders/photon.js
+++ b/src/geocoders/photon.js
@@ -40,7 +40,7 @@ export default {
           lat: latLng.lat,
           lon: latLng.lng
         },
-        this.options.geocodingQueryParams
+        this.options.reverseQueryParams
       );
 
       getJSON(


### PR DESCRIPTION
Reverse geocoding query parameters are now built using the reverseQueryParams option instead of geocodingQueryParams, as described in the documentation.