### PR TITLE
Adding properties to mapbox results

### DIFF
--- a/src/geocoders/mapbox.js
+++ b/src/geocoders/mapbox.js
@@ -43,10 +43,21 @@ export default {
             } else {
               latLngBounds = L.latLngBounds(latLng, latLng);
             }
+
+            var props = {}, id, j;
+            props['text'] = loc.text;
+            props['address'] = loc.address;
+
+            for (j = 0; j < loc.context.length; j++) {
+              id = loc.context[j].id.split('.')[0];
+              props[id] = loc.context[j].text;
+            }
+
             results[i] = {
               name: loc.place_name,
               bbox: latLngBounds,
-              center: latLng
+              center: latLng,
+              properties: props
             };
           }
         }


### PR DESCRIPTION
This PR adds a properties object to mapbox results. The properties will contain the `text` and `address` (if available) fields as well as any fields available in the `context` object. For example, given the following result from the Mapbox API:

```
{
  "id": "address.4999081611113982",
  "type": "Feature",
  "place_type": [
    "address"
  ],
  "relevance": 1,
  "properties": {},
  "text": "Pearson Road",
  "place_name": "1000 Pearson Road, Jasper, Georgia 30143, United States",
  "center": [
    34.422905,
    -84.402372
  ],
  "geometry": {
    "type": "Point",
    "coordinates": [
      -84.402372,
      34.422905
    ],
    "interpolated": true
  },
  "address": "1000",
  "context": [
    {
      "id": "postcode.12517861516665550",
      "text": "30143"
    },
    {
      "id": "place.12069773894564040",
      "wikidata": "Q519096",
      "text": "Jasper"
    },
    {
      "id": "region.219644",
      "short_code": "US-GA",
      "wikidata": "Q1428",
      "text": "Georgia"
    },
    {
      "id": "country.3145",
      "short_code": "us",
      "wikidata": "Q30",
      "text": "United States"
    }
  ]
}
```

result.properties will contain the following object:

```
{
  "text": "Pearson Road",
  "address": "1000",
  "postcode": "30143",
  "place": "Jasper",
  "region": "Georgia",
  "country": "United States"
}
```