### PR TITLE
Add Neutrino API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The plugin supports many different data providers:
 * [Photon](http://photon.komoot.de/)
 * [Mapzen Search](https://mapzen.com/projects/search)
 * [HERE Geocoder API](https://developer.here.com/documentation/geocoder/topics/introduction.html)
+* [Neutrino API](https://www.neutrinoapi.com/api/geocode-address/)
 
 The plugin can easily be extended to support other providers. Current extensions:
 

--- a/src/geocoders/neutrino.js
+++ b/src/geocoders/neutrino.js
@@ -1,0 +1,80 @@
+import L from 'leaflet';
+import { getJSON } from '../util';
+
+export default {
+  class: L.Class.extend({
+    options: {
+      serviceUrl: 'https://neutrinoapi.com/'
+    },
+
+    initialize: function(accessToken, userName) {
+      this._accessToken = accessToken;
+      this._userName = userName;
+    },
+
+    geocode: function(query, cb, context) {
+      //get three words and make a dot based string
+      getJSON(
+        this.options.serviceUrl + 'geocode-address',
+        {
+          'api-key': this._accessToken,
+          'user-id': this._userName,
+          address: query.split(/\s+/).join('.')
+        },
+        function(data) {
+          var results = [],
+            latLng,
+            latLngBounds;
+          if (data.hasOwnProperty('locations')) {
+              data.geometry = data.locations[0];
+            latLng = L.latLng(data.geometry['latitude'], data.geometry['longitude']);
+            latLngBounds = L.latLngBounds(latLng, latLng);
+            results[0] = {
+              name: data.geometry.address,
+              bbox: latLngBounds,
+              center: latLng
+            };
+          }
+
+          cb.call(context, results);
+        }
+      );
+    },
+
+    suggest: function(query, cb, context) {
+      return this.geocode(query, cb, context);
+    },
+
+    reverse: function(location, scale, cb, context) {
+      getJSON(
+        this.options.serviceUrl + 'geocode-reverse',
+        {
+          'api-key': this._accessToken,
+          'user-id': this._userName,
+          latitude: location.lat,
+          longitude:  location.lng
+        },
+        function(data) {
+          var results = [],
+            latLng,
+            latLngBounds;
+          if (data.status.status == 200 && data.found) {
+
+            latLng = L.latLng(location.lat, location.lng);
+            latLngBounds = L.latLngBounds(latLng, latLng);
+            results[0] = {
+              name: data.address,
+              bbox: latLngBounds,
+              center: latLng
+            };
+          }
+          cb.call(context, results);
+        }
+      );
+    }
+  }),
+
+  factory: function(accessToken) {
+    return new L.Control.Geocoder.Neutrino(accessToken);
+  }
+};

--- a/src/geocoders/neutrino.js
+++ b/src/geocoders/neutrino.js
@@ -4,21 +4,23 @@ import { getJSON } from '../util';
 export default {
   class: L.Class.extend({
     options: {
+      userId: '<insert your userId here>',
+      apiKey: '<insert your apiKey here>',
       serviceUrl: 'https://neutrinoapi.com/'
     },
 
-    initialize: function(accessToken, userName) {
-      this._accessToken = accessToken;
-      this._userName = userName;
+    initialize: function(options) {
+      L.Util.setOptions(this, options);
     },
 
+    // https://www.neutrinoapi.com/api/geocode-address/
     geocode: function(query, cb, context) {
-      //get three words and make a dot based string
       getJSON(
         this.options.serviceUrl + 'geocode-address',
         {
-          'api-key': this._accessToken,
-          'user-id': this._userName,
+          apiKey: this.options.apiKey,
+          userId: this.options.userId,
+          //get three words and make a dot based string
           address: query.split(/\s+/).join('.')
         },
         function(data) {
@@ -26,7 +28,7 @@ export default {
             latLng,
             latLngBounds;
           if (data.hasOwnProperty('locations')) {
-              data.geometry = data.locations[0];
+            data.geometry = data.locations[0];
             latLng = L.latLng(data.geometry['latitude'], data.geometry['longitude']);
             latLngBounds = L.latLngBounds(latLng, latLng);
             results[0] = {
@@ -45,21 +47,21 @@ export default {
       return this.geocode(query, cb, context);
     },
 
+    // https://www.neutrinoapi.com/api/geocode-reverse/
     reverse: function(location, scale, cb, context) {
       getJSON(
         this.options.serviceUrl + 'geocode-reverse',
         {
-          'api-key': this._accessToken,
-          'user-id': this._userName,
+          apiKey: this.options.apiKey,
+          userId: this.options.userId,
           latitude: location.lat,
-          longitude:  location.lng
+          longitude: location.lng
         },
         function(data) {
           var results = [],
             latLng,
             latLngBounds;
           if (data.status.status == 200 && data.found) {
-
             latLng = L.latLng(location.lat, location.lng);
             latLngBounds = L.latLngBounds(latLng, latLng);
             results[0] = {

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import Photon from './geocoders/photon';
 import Mapzen from './geocoders/mapzen';
 import ArcGis from './geocoders/arcgis';
 import HERE from './geocoders/here';
+import Neutrino from './geocoders/neutrino';
 
 var Geocoder = L.Util.extend(Control.class, {
   Nominatim: Nominatim.class,
@@ -31,7 +32,9 @@ var Geocoder = L.Util.extend(Control.class, {
   ArcGis: ArcGis.class,
   arcgis: ArcGis.factory,
   HERE: HERE.class,
-  here: HERE.factory
+  here: HERE.factory,
+  Neutrino: Neutrino.class,
+  neutrino: Neutrino.factory,
 });
 
 export default Geocoder;


### PR DESCRIPTION
- [x]  Implement API
- [ ]  Wait for support response in order to have a CORS header included in the response.

```
Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at https://neutrinoapi.com/geocode-address?apiKey=xxx&userId=simon04&address=vienna. (Reason: CORS header ‘Access-Control-Allow-Origin’ missing).
```