### PR TITLE
Allow function overwrite for markGeocode

### DIFF
--- a/Control.Geocoder.css
+++ b/Control.Geocoder.css
@@ -39,7 +39,7 @@
   font-size: 120%;
   border: 0;
   background-color: transparent;
-  width: 246px;
+  width: 200px;
 }
 
 .leaflet-control-geocoder-icon {

--- a/src/control.js
+++ b/src/control.js
@@ -130,9 +130,9 @@ export var Geocoder = L.Control.extend({
     }
 
     if (this.options.defaultMarkGeocode) {
-      typeof this.options.defaultMarkGeocode == 'function' ?
-        this.on('markgeocode', this.options.defaultMarkGeocode, this) :
-        this.on('markgeocode', this.markGeocode, this);
+      typeof this.options.defaultMarkGeocode == 'function'
+        ? this.on('markgeocode', this.options.defaultMarkGeocode, this)
+        : this.on('markgeocode', this.markGeocode, this);
     }
 
     this.on('startgeocode', this.addThrobberClass, this);

--- a/src/control.js
+++ b/src/control.js
@@ -130,7 +130,9 @@ export var Geocoder = L.Control.extend({
     }
 
     if (this.options.defaultMarkGeocode) {
-      this.on('markgeocode', this.markGeocode, this);
+      typeof this.options.defaultMarkGeocode == 'function' ?
+        this.on('markgeocode', this.options.defaultMarkGeocode, this) :
+        this.on('markgeocode', this.markGeocode, this);
     }
 
     this.on('startgeocode', this.addThrobberClass, this);


### PR DESCRIPTION
I added a simple one line modification that I am using for my own purposes. It keeps current functionality intact while also allowing a function to passed in to overwrite the default markGeocode function, in case the developer needs to incorporate more specific functionality.

Please pull if you think this is a worthwhile addition. I'd be happy to update the documentation accordingly.