### PR TITLE
Add an aria-label to the geocoder control button

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ L.Control.geocoder(options);
 | `position`         | String    | `"topright"`                         | Control [position](https://leafletjs.com/reference.html#control-positions)                                    |
 | `placeholder`      | String    | `"Search..."`                        | Placeholder text for text input                                                                               |
 | `errorMessage`     | String    | `"Nothing found."`                   | Message when no result found / geocoding error occurs                                                         |
+| `iconLabel`        | String    | `"Initiate a new search"`            | Accessibility label for the search icon used by screen readers                                                |
 | `geocoder`         | IGeocoder | `new L.Control.Geocoder.Nominatim()` | Object to perform the actual geocoding queries                                                                |
 | `showUniqueResult` | Boolean   | `true`                               | Immediately show the unique result without prompting for alternatives                                         |
 | `showResultIcons`  | Boolean   | `false`                              | Show icons for geocoding results (if available); supported by Nominatim                                       |

--- a/src/control.js
+++ b/src/control.js
@@ -47,6 +47,7 @@ export var Geocoder = L.Control.extend({
 
     icon.innerHTML = '&nbsp;';
     icon.type = 'button';
+    icon.setAttribute('aria-label', 'Initiate a new search');
 
     input = this._input = L.DomUtil.create('input', '', form);
     input.type = 'text';

--- a/src/control.js
+++ b/src/control.js
@@ -10,6 +10,7 @@ export var Geocoder = L.Control.extend({
     position: 'topright',
     placeholder: 'Search...',
     errorMessage: 'Nothing found.',
+    iconLabel: 'Initiate a new search',
     queryMinLength: 1,
     suggestMinLength: 3,
     suggestTimeout: 250,
@@ -47,7 +48,7 @@ export var Geocoder = L.Control.extend({
 
     icon.innerHTML = '&nbsp;';
     icon.type = 'button';
-    icon.setAttribute('aria-label', 'Initiate a new search');
+    icon.setAttribute('aria-label', this.options.iconLabel);
 
     input = this._input = L.DomUtil.create('input', '', form);
     input.type = 'text';


### PR DESCRIPTION
- More information can be found at https://www.w3.org/TR/wai-aria/#aria-label where the purpose of the "aria-label" attribute is described
- If there is no label of an interactive UI element, screen readers might have difficulties to extract the purpose of the element.
- The aria-label attribute helps screen readers by offering a label describing the purpose of the UI element and what happens when clicking on it

This pull request fixes #262