### PR TITLE
Allow setting search input element id through option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,19 +101,20 @@ L.Control.geocoder(options);
 
 ### Options
 
-| Option             | Type      | Default                              | Description                                                                                                   |
-| ------------------ | --------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
-| `collapsed`        | Boolean   | `true`                               | Collapse control unless hovered/clicked                                                                       |
-| `expand`           | String    | `"touch"`                            | How to expand a collapsed control: `touch` or `click` or `hover`                                              |
-| `position`         | String    | `"topright"`                         | Control [position](https://leafletjs.com/reference.html#control-positions)                                    |
-| `placeholder`      | String    | `"Search..."`                        | Placeholder text for text input                                                                               |
-| `errorMessage`     | String    | `"Nothing found."`                   | Message when no result found / geocoding error occurs                                                         |
-| `geocoder`         | IGeocoder | `new L.Control.Geocoder.Nominatim()` | Object to perform the actual geocoding queries                                                                |
-| `showUniqueResult` | Boolean   | `true`                               | Immediately show the unique result without prompting for alternatives                                         |
-| `showResultIcons`  | Boolean   | `false`                              | Show icons for geocoding results (if available); supported by Nominatim                                       |
-| `suggestMinLength` | Number    | `3`                                  | Minimum number characters before suggest functionality is used (if available from geocoder)                   |
-| `suggestTimeout`   | Number    | `250`                                | Number of milliseconds after typing stopped before suggest functionality is used (if available from geocoder) |
-| `queryMinLength`   | Number    | `1`                                  | Minimum number of characters in search text before performing a query                                         |
+| Option               | Type      | Default                              | Description                                                                                                   |
+| -------------------- | --------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| `collapsed`          | Boolean   | `true`                               | Collapse control unless hovered/clicked                                                                       |
+| `expand`             | String    | `"touch"`                            | How to expand a collapsed control: `touch` or `click` or `hover`                                              |
+| `position`           | String    | `"topright"`                         | Control [position](https://leafletjs.com/reference.html#control-positions)                                    |
+| `placeholder`        | String    | `"Search..."`                        | Placeholder text for text input                                                                               |
+| `errorMessage`       | String    | `"Nothing found."`                   | Message when no result found / geocoding error occurs                                                         |
+| `geocoder`           | IGeocoder | `new L.Control.Geocoder.Nominatim()` | Object to perform the actual geocoding queries                                                                |
+| `showUniqueResult`   | Boolean   | `true`                               | Immediately show the unique result without prompting for alternatives                                         |
+| `showResultIcons`    | Boolean   | `false`                              | Show icons for geocoding results (if available); supported by Nominatim                                       |
+| `suggestMinLength`   | Number    | `3`                                  | Minimum number characters before suggest functionality is used (if available from geocoder)                   |
+| `suggestTimeout`     | Number    | `250`                                | Number of milliseconds after typing stopped before suggest functionality is used (if available from geocoder) |
+| `queryMinLength`     | Number    | `1`                                  | Minimum number of characters in search text before performing a query                                         |
+| `defaultMarkGeocode` | Boolean   | `true`                               | Add a marker to the map for the selected result                                                               |
 
 ### Methods
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ L.Control.geocoder(options);
 | `suggestTimeout`     | Number    | `250`                                | Number of milliseconds after typing stopped before suggest functionality is used (if available from geocoder) |
 | `queryMinLength`     | Number    | `1`                                  | Minimum number of characters in search text before performing a query                                         |
 | `defaultMarkGeocode` | Boolean   | `true`                               | Add a marker to the map for the selected result                                                               |
+| `searchInputId`      | String    | `''`                                 | Id of the search input element                                                                                |
 
 ### Methods
 

--- a/src/control.js
+++ b/src/control.js
@@ -49,6 +49,9 @@ export var Geocoder = L.Control.extend({
     icon.type = 'button';
 
     input = this._input = L.DomUtil.create('input', '', form);
+    if (this.options.searchInputId) {
+      input.id = this.options.searchInputId;
+    }
     input.type = 'text';
     input.placeholder = this.options.placeholder;
     L.DomEvent.disableClickPropagation(input);


### PR DESCRIPTION
Users can set the search input element id through specifying `searchInputId` option.

Also adds docs to `defaultMarkGeocode` to README.