### PR TITLE
Collapse search result on iOS devices

### DIFF
--- a/src/control.js
+++ b/src/control.js
@@ -261,7 +261,7 @@ export var Geocoder = L.Control.extend({
         this._geocodeResultSelected(result);
         L.DomEvent.on(
           li,
-          'click',
+          'click touchend',
           function() {
             if (this.options.collapsed) {
               this._collapse();

--- a/src/geocoders/here.js
+++ b/src/geocoders/here.js
@@ -56,6 +56,7 @@ export var HERE = L.Class.extend({
           );
           results[i] = {
             name: loc.address.label,
+            properties: loc.address,
             bbox: latLngBounds,
             center: latLng
           };


### PR DESCRIPTION
This refers to Problem 2 of #231. I was successfully collapsing the search results after selecting a list item on my iOS Device after adding the event. The other PR is included in here too. Sorry for that mess.  Thanks for your work!