### PR TITLE
Check touch for event type instead of expand option

### DIFF
--- a/src/control.js
+++ b/src/control.js
@@ -94,10 +94,10 @@ export var Geocoder = L.Control.extend({
           },
           this
         );
-      } else if (L.Browser.touch && this.options.expand === 'touch') {
+      } else if (this.options.expand === 'touch') {
         L.DomEvent.addListener(
           container,
-          'touchstart mousedown',
+          L.Browser.touch ? 'touchstart mousedown' : 'mousedown',
           function(e) {
             this._toggle();
             e.preventDefault(); // mobile: clicking focuses the icon, so UI expands and immediately collapses


### PR DESCRIPTION
Suggestion to fix #255 by moving the `L.Browser.touch` check from the `expand` option clause down to the event type.

This way the default `expand=touch` option always works with desktop browsers, independent of their `touch`/`pointer` support.

Leaflet itself uses the same expression in [Draggable.js](https://github.com/Leaflet/Leaflet/blob/37d2fd15ad6518c254fae3e033177e96c48b5012/src/dom/Draggable.js#L24)

Tested with Chrome and Firefox and their mobile screen emulators only.
