### PR TITLE
Add suggestion support for HERE.

### DIFF
--- a/src/control.js
+++ b/src/control.js
@@ -265,13 +265,13 @@ export var Geocoder = L.Control.extend({
         this._preventBlurCollapse = true;
         L.DomEvent.stop(e);
 
-        if(result.bbox || result.center) {
+        if (result.bbox || result.center) {
           this._geocodeResultSelected(result);
         } else {
           this.setQuery(result.name);
           this._geocode();
         }
-        
+
         L.DomEvent.on(
           li,
           'click touchend',

--- a/src/control.js
+++ b/src/control.js
@@ -89,7 +89,7 @@ export var Geocoder = L.Control.extend({
           'click',
           function(e) {
             if (e.button === 0 && e.detail !== 2) {
-              this._toggle();
+            this._toggle();
             }
           },
           this
@@ -264,7 +264,14 @@ export var Geocoder = L.Control.extend({
         // for #142.
         this._preventBlurCollapse = true;
         L.DomEvent.stop(e);
-        this._geocodeResultSelected(result);
+
+        if(result.bbox || result.center) {
+          this._geocodeResultSelected(result);
+        } else {
+          this.setQuery(result.name);
+          this._geocode();
+        }
+        
         L.DomEvent.on(
           li,
           'click touchend',

--- a/src/control.js
+++ b/src/control.js
@@ -89,7 +89,7 @@ export var Geocoder = L.Control.extend({
           'click',
           function(e) {
             if (e.button === 0 && e.detail !== 2) {
-            this._toggle();
+              this._toggle();
             }
           },
           this

--- a/src/geocoders/here.js
+++ b/src/geocoders/here.js
@@ -61,7 +61,7 @@ export var HERE = L.Class.extend({
           loc = data.suggestions[i];
           results[i] = {
             name: loc.label,
-            properties: loc.address,
+            properties: loc.address
           };
         }
       }

--- a/src/geocoders/here.js
+++ b/src/geocoders/here.js
@@ -4,6 +4,7 @@ export var HERE = L.Class.extend({
   options: {
     geocodeUrl: 'https://geocoder.api.here.com/6.2/geocode.json',
     reverseGeocodeUrl: 'https://reverse.geocoder.api.here.com/6.2/reversegeocode.json',
+    suggestUrl: 'https://autocomplete.geocoder.api.here.com/6.2/suggest.json',
     app_id: '<insert your app_id here>',
     app_code: '<insert your app_code here>',
     geocodingQueryParams: {},
@@ -24,6 +25,17 @@ export var HERE = L.Class.extend({
     params = L.Util.extend(params, this.options.geocodingQueryParams);
     this.getJSON(this.options.geocodeUrl, params, cb, context);
   },
+  suggest: function(query, cb, context) {
+    var params = {
+      query: query,
+      app_id: this.options.app_id,
+      app_code: this.options.app_code,
+      gen: 9,
+      jsonattributes: 1
+    };
+    params = L.Util.extend(params, this.options.geocodingQueryParams);
+    this.getSuggestJSON(this.options.suggestUrl, params, cb, context);
+  },
   reverse: function(location, scale, cb, context) {
     var _proxRadius = this.options.reverseGeocodeProxRadius
       ? this.options.reverseGeocodeProxRadius
@@ -39,6 +51,22 @@ export var HERE = L.Class.extend({
     };
     params = L.Util.extend(params, this.options.reverseQueryParams);
     this.getJSON(this.options.reverseGeocodeUrl, params, cb, context);
+  },
+  getSuggestJSON: function(url, params, cb, context) {
+    getJSON(url, params, function(data) {
+      var results = [],
+        loc;
+      if (data.suggestions && data.suggestions.length) {
+        for (var i = 0; i <= data.suggestions.length - 1; i++) {
+          loc = data.suggestions[i];
+          results[i] = {
+            name: loc.label,
+            properties: loc.address,
+          };
+        }
+      }
+      cb.call(context, results);
+    });
   },
   getJSON: function(url, params, cb, context) {
     getJSON(url, params, function(data) {


### PR DESCRIPTION
I've added support for getting suggestions with the HERE geocode provider. 

The primary issue with the HERE api response is that there is no coordinate information on the response (see below). In theory a provider that offers a suggestion should be able to look up that exact suggestion. So I also adjusted the control to call `setQuery` and trigger a `_geocode` request when selecting a suggestion with no bbox or center. Let me know if it's better to find a way around this approach. 

```
{
    "suggestions": [
        {
            "label": "United States, GA, Atlanta",
            "language": "en",
            "countryCode": "USA",
            "locationId": "NT_fw7oye40be288veJdXfo8D",
            "address": {
                "country": "United States",
                "state": "GA",
                "county": "Fulton",
                "city": "Atlanta",
                "postalCode": "30303"
            },
            "matchLevel": "city"
        },
        {
            "label": "México, Cuautitlán Izcalli, Atlanta",
            "language": "es",
            "countryCode": "MEX",
            "locationId": "NT_CZjO39V8qEqSvz-TcADJxC",
            "address": {
                "country": "México",
                "state": "EDOMEX",
                "city": "Cuautitlán Izcalli",
                "district": "Atlanta",
                "postalCode": "54740"
            },
            "matchLevel": "district"
        },
        {
            "label": "Deutschland, Remseck am Neckar, Atlantastraße",
            "language": "de",
            "countryCode": "DEU",
            "locationId": "NT_7OkjmvLRX63KZeLmTW-48D",
            "address": {
                "country": "Deutschland",
                "state": "Baden-Württemberg",
                "county": "Ludwigsburg",
                "city": "Remseck am Neckar",
                "district": "Pattonville",
                "street": "Atlantastraße",
                "postalCode": "71686"
            },
            "matchLevel": "street"
        },
        {
            "label": "United States, GA, Atlanta, Atlanta University Center",
            "language": "en",
            "countryCode": "USA",
            "locationId": "NT_1E366mzP4hMOPK4LS6R.2A",
            "address": {
                "country": "United States",
                "state": "GA",
                "county": "Fulton",
                "city": "Atlanta",
                "district": "Atlanta University Center",
                "postalCode": "30314"
            },
            "matchLevel": "district"
        },
        {
            "label": "United States, TX, Atlanta",
            "language": "en",
            "countryCode": "USA",
            "locationId": "NT_PS1qFrX6QAmUhmXiCGE57A",
            "address": {
                "country": "United States",
                "state": "TX",
                "county": "Cass",
                "city": "Atlanta",
                "postalCode": "75551"
            },
            "matchLevel": "city"
        }
    ]
}
```