### PR TITLE
Here maps new api

### DIFF
--- a/spec/__snapshots__/here.spec.ts.snap
+++ b/spec/__snapshots__/here.spec.ts.snap
@@ -47,3 +47,42 @@ Array [
   ],
 ]
 `;
+
+exports[`L.Control.Geocoder.HEREv2 geocodes Innsbruck 1`] = `
+Array [
+  Array [
+    Array [
+      Object {
+        "bbox": Object {
+          "_northEast": Object {
+            "lat": 42.36355,
+            "lng": -71.05439,
+          },
+          "_southWest": Object {
+            "lat": 42.36355,
+            "lng": -71.05439,
+          },
+        },
+        "center": Object {
+          "lat": 42.36355,
+          "lng": -71.05439,
+        },
+        "name": "Salumeria Italiana, 151 Richmond St, Boston, MA 02109, United States",
+        "properties": Object {
+          "city": "Boston",
+          "countryCode": "USA",
+          "countryName": "United States",
+          "county": "Suffolk",
+          "district": "North End",
+          "houseNumber": "151",
+          "label": "Salumeria Italiana, 151 Richmond St, Boston, MA 02109, United States",
+          "postalCode": "02109",
+          "state": "Massachusetts",
+          "stateCode": "MA",
+          "street": "Richmond St",
+        },
+      },
+    ],
+  ],
+]
+`;

--- a/spec/here.spec.ts
+++ b/spec/here.spec.ts
@@ -1,5 +1,6 @@
 import { testXMLHttpRequest } from './mockXMLHttpRequest';
 import { HERE } from '../src/geocoders/here';
+import { HEREv2 } from '../src/geocoders/here';
 import { GeocodingResult } from '../src/geocoders/api';
 
 describe('L.Control.Geocoder.HERE', () => {
@@ -82,6 +83,86 @@ describe('L.Control.Geocoder.HERE', () => {
       _northEast: { lat: 47.35922, lng: 11.45587 },
       _southWest: { lat: 47.21082, lng: 11.30194 }
     });
+    expect(callback.mock.calls).toMatchSnapshot();
+  });
+});
+
+describe('L.Control.Geocoder.HEREv2', () => {
+  it('geocodes Innsbruck', () => {
+    let geocodingParams = {at:'50.62925,3.057256'};
+    const geocoder = new HEREv2({ apiKey: 'xxx', geocodingQueryParams: geocodingParams });
+    const callback = jest.fn();
+    testXMLHttpRequest(
+      'https://geocode.search.hereapi.com/v1/discover?q=Innsbruck&apiKey=xxx&at=50.62925%2C3.057256',
+      {
+        "items": [
+          {
+            "title": "Salumeria Italiana",
+            "id": "here:pds:place:840drt3p-898f6ee434794fe59895e71ccf9381e1",
+            "ontologyId": "here:cm:ontology:restaurant",
+            "resultType": "place",
+            "address": {
+              "label": "Salumeria Italiana, 151 Richmond St, Boston, MA 02109, United States",
+              "countryCode": "USA",
+              "countryName": "United States",
+              "stateCode": "MA",
+              "state": "Massachusetts",
+              "county": "Suffolk",
+              "city": "Boston",
+              "district": "North End",
+              "street": "Richmond St",
+              "postalCode": "02109",
+              "houseNumber": "151"
+            },
+            "position": { "lat": 42.36355, "lng": -71.05439 },
+            "access": [{ "lat": 42.3635, "lng": -71.05448 }],
+            "distance": 11,
+            "categories": [
+              { "id": "600-6300-0066", "name": "Grocery", "primary": true },
+              { "id": "100-1000-0000", "name": "Restaurant" },
+              { "id": "100-1000-0006", "name": "Deli" },
+              { "id": "600-6300-0067", "name": "Specialty Food Store" }
+            ],
+            "references": [
+              { "supplier": { "id": "core" }, "id": "31213861" },
+              { "supplier": { "id": "tripadvisor" }, "id": "3172680" },
+              { "supplier": { "id": "yelp" }, "id": "JNx0DlfndRurT-8KhSym7g" },
+              { "supplier": { "id": "yelp" }, "id": "P44VNcZUUNZfiFy-c4SUJw" }
+            ],
+            "foodTypes": [
+              { "id": "304-000", "name": "Italian", "primary": true },
+              { "id": "800-057", "name": "Pizza" },
+              { "id": "800-060", "name": "Sandwich" }
+            ],
+            "contacts": [
+              {
+                "phone": [{ "value": "+16175234946" }, { "value": "+16175238743" }, { "value": "+16177204243" }],
+                "fax": [{ "value": "+16175234946" }],
+                "www": [
+                  { "value": "http://www.salumeriaitaliana.com" }
+                ],
+                "email": [{ "value": "contact@salumeriaitaliana.com" }]
+              }
+            ],
+            "openingHours": [
+              {
+                "text": ["Mon-Sat: 08:00 - 17:00", "Sun: 10:00 - 16:00"],
+                "isOpen": false,
+                "structured": [
+                  { "start": "T080000", "duration": "PT11H00M", "recurrence": "FREQ:DAILY;BYDAY:MO,TU,WE,TH,FR,SA" },
+                  { "start": "T100000", "duration": "PT06H00M", "recurrence": "FREQ:DAILY;BYDAY:SU" }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      () => geocoder.geocode('Innsbruck', callback)
+    );
+
+    const feature: GeocodingResult = callback.mock.calls[0][0][0];
+    expect(feature.name).toBe('Salumeria Italiana, 151 Richmond St, Boston, MA 02109, United States');
+    expect(feature.center).toStrictEqual({ "lat": 42.36355, "lng": -71.05439 });
     expect(callback.mock.calls).toMatchSnapshot();
   });
 });

--- a/spec/here.spec.ts
+++ b/spec/here.spec.ts
@@ -89,68 +89,74 @@ describe('L.Control.Geocoder.HERE', () => {
 
 describe('L.Control.Geocoder.HEREv2', () => {
   it('geocodes Innsbruck', () => {
-    let geocodingParams = {at:'50.62925,3.057256'};
+    const geocodingParams = { at: '50.62925,3.057256' };
     const geocoder = new HEREv2({ apiKey: 'xxx', geocodingQueryParams: geocodingParams });
     const callback = jest.fn();
     testXMLHttpRequest(
       'https://geocode.search.hereapi.com/v1/discover?q=Innsbruck&apiKey=xxx&at=50.62925%2C3.057256',
       {
-        "items": [
+        items: [
           {
-            "title": "Salumeria Italiana",
-            "id": "here:pds:place:840drt3p-898f6ee434794fe59895e71ccf9381e1",
-            "ontologyId": "here:cm:ontology:restaurant",
-            "resultType": "place",
-            "address": {
-              "label": "Salumeria Italiana, 151 Richmond St, Boston, MA 02109, United States",
-              "countryCode": "USA",
-              "countryName": "United States",
-              "stateCode": "MA",
-              "state": "Massachusetts",
-              "county": "Suffolk",
-              "city": "Boston",
-              "district": "North End",
-              "street": "Richmond St",
-              "postalCode": "02109",
-              "houseNumber": "151"
+            title: 'Salumeria Italiana',
+            id: 'here:pds:place:840drt3p-898f6ee434794fe59895e71ccf9381e1',
+            ontologyId: 'here:cm:ontology:restaurant',
+            resultType: 'place',
+            address: {
+              label: 'Salumeria Italiana, 151 Richmond St, Boston, MA 02109, United States',
+              countryCode: 'USA',
+              countryName: 'United States',
+              stateCode: 'MA',
+              state: 'Massachusetts',
+              county: 'Suffolk',
+              city: 'Boston',
+              district: 'North End',
+              street: 'Richmond St',
+              postalCode: '02109',
+              houseNumber: '151'
             },
-            "position": { "lat": 42.36355, "lng": -71.05439 },
-            "access": [{ "lat": 42.3635, "lng": -71.05448 }],
-            "distance": 11,
-            "categories": [
-              { "id": "600-6300-0066", "name": "Grocery", "primary": true },
-              { "id": "100-1000-0000", "name": "Restaurant" },
-              { "id": "100-1000-0006", "name": "Deli" },
-              { "id": "600-6300-0067", "name": "Specialty Food Store" }
+            position: { lat: 42.36355, lng: -71.05439 },
+            access: [{ lat: 42.3635, lng: -71.05448 }],
+            distance: 11,
+            categories: [
+              { id: '600-6300-0066', name: 'Grocery', primary: true },
+              { id: '100-1000-0000', name: 'Restaurant' },
+              { id: '100-1000-0006', name: 'Deli' },
+              { id: '600-6300-0067', name: 'Specialty Food Store' }
             ],
-            "references": [
-              { "supplier": { "id": "core" }, "id": "31213861" },
-              { "supplier": { "id": "tripadvisor" }, "id": "3172680" },
-              { "supplier": { "id": "yelp" }, "id": "JNx0DlfndRurT-8KhSym7g" },
-              { "supplier": { "id": "yelp" }, "id": "P44VNcZUUNZfiFy-c4SUJw" }
+            references: [
+              { supplier: { id: 'core' }, id: '31213861' },
+              { supplier: { id: 'tripadvisor' }, id: '3172680' },
+              { supplier: { id: 'yelp' }, id: 'JNx0DlfndRurT-8KhSym7g' },
+              { supplier: { id: 'yelp' }, id: 'P44VNcZUUNZfiFy-c4SUJw' }
             ],
-            "foodTypes": [
-              { "id": "304-000", "name": "Italian", "primary": true },
-              { "id": "800-057", "name": "Pizza" },
-              { "id": "800-060", "name": "Sandwich" }
+            foodTypes: [
+              { id: '304-000', name: 'Italian', primary: true },
+              { id: '800-057', name: 'Pizza' },
+              { id: '800-060', name: 'Sandwich' }
             ],
-            "contacts": [
+            contacts: [
               {
-                "phone": [{ "value": "+16175234946" }, { "value": "+16175238743" }, { "value": "+16177204243" }],
-                "fax": [{ "value": "+16175234946" }],
-                "www": [
-                  { "value": "http://www.salumeriaitaliana.com" }
+                phone: [
+                  { value: '+16175234946' },
+                  { value: '+16175238743' },
+                  { value: '+16177204243' }
                 ],
-                "email": [{ "value": "contact@salumeriaitaliana.com" }]
+                fax: [{ value: '+16175234946' }],
+                www: [{ value: 'http://www.salumeriaitaliana.com' }],
+                email: [{ value: 'contact@salumeriaitaliana.com' }]
               }
             ],
-            "openingHours": [
+            openingHours: [
               {
-                "text": ["Mon-Sat: 08:00 - 17:00", "Sun: 10:00 - 16:00"],
-                "isOpen": false,
-                "structured": [
-                  { "start": "T080000", "duration": "PT11H00M", "recurrence": "FREQ:DAILY;BYDAY:MO,TU,WE,TH,FR,SA" },
-                  { "start": "T100000", "duration": "PT06H00M", "recurrence": "FREQ:DAILY;BYDAY:SU" }
+                text: ['Mon-Sat: 08:00 - 17:00', 'Sun: 10:00 - 16:00'],
+                isOpen: false,
+                structured: [
+                  {
+                    start: 'T080000',
+                    duration: 'PT11H00M',
+                    recurrence: 'FREQ:DAILY;BYDAY:MO,TU,WE,TH,FR,SA'
+                  },
+                  { start: 'T100000', duration: 'PT06H00M', recurrence: 'FREQ:DAILY;BYDAY:SU' }
                 ]
               }
             ]
@@ -161,8 +167,10 @@ describe('L.Control.Geocoder.HEREv2', () => {
     );
 
     const feature: GeocodingResult = callback.mock.calls[0][0][0];
-    expect(feature.name).toBe('Salumeria Italiana, 151 Richmond St, Boston, MA 02109, United States');
-    expect(feature.center).toStrictEqual({ "lat": 42.36355, "lng": -71.05439 });
+    expect(feature.name).toBe(
+      'Salumeria Italiana, 151 Richmond St, Boston, MA 02109, United States'
+    );
+    expect(feature.center).toStrictEqual({ lat: 42.36355, lng: -71.05439 });
     expect(callback.mock.calls).toMatchSnapshot();
   });
 });

--- a/src/geocoders/here.ts
+++ b/src/geocoders/here.ts
@@ -13,7 +13,6 @@ export interface HereOptions extends GeocoderOptions {
   app_id: string;
   app_code: string;
   reverseGeocodeProxRadius: null;
-  reverseGeocodeUrl: string;
   apiKey: string;
 }
 
@@ -26,8 +25,7 @@ export class HERE implements IGeocoder {
     app_id: '',
     app_code: '',
     reverseGeocodeProxRadius: null,
-    apiKey: '',
-    reverseGeocodeUrl: ''
+    apiKey: ''
   };
 
   constructor(options?: Partial<HereOptions>) {
@@ -89,8 +87,7 @@ export class HERE implements IGeocoder {
 export class HEREv2 implements IGeocoder {
 
   options: HereOptions = {
-    serviceUrl: 'https://geocode.search.hereapi.com/v1/discover',
-    reverseGeocodeUrl: 'https://revgeocode.search.hereapi.com/v1/revgeocode',
+    serviceUrl: 'https://geocode.search.hereapi.com/v1',
     apiKey: '<insert your api key>',
     reverseGeocodeProxRadius: null,
     app_id: '',
@@ -112,7 +109,7 @@ export class HEREv2 implements IGeocoder {
       throw Error('at / in parameters not found. Please define coordinates (at=latitude,longitude) or other (in) in your geocodingQueryParams.');
     }
 
-    this.getJSON(this.options.serviceUrl, params, cb, context);
+    this.getJSON(this.options.serviceUrl + '/discover', params, cb, context);
   }
 
   reverse(location: L.LatLngLiteral, scale: number, cb: GeocodingCallback, context?: any): void {
@@ -129,7 +126,7 @@ export class HEREv2 implements IGeocoder {
       params.limit = proxRadius;
     }
 
-    this.getJSON(this.options.reverseGeocodeUrl, params, cb, context);
+    this.getJSON(this.options.serviceUrl + '/revgeocode', params, cb, context);
   }
 
   getJSON(url: string, params: any, cb: GeocodingCallback, context?: any) {


### PR DESCRIPTION
Modifications for Here maps API. 

- [Geocoding]( https://developer.here.com/documentation/geocoding-search-api/dev_guide/topics-api/code-geocode-examples.html)
- [Reverse](https://developer.here.com/documentation/geocoding-search-api/dev_guide/topics-api/code-revgeocode.html)

Impossible to use the old one as the identification method changed. (Not event prompted when creating a account)

/!\ This is a pretty big modification that might break people who use the old one /!\

(And i added a changelog)