### PR TITLE
photon: update to photon.komoot.io

### DIFF
--- a/src/geocoders/photon.js
+++ b/src/geocoders/photon.js
@@ -3,8 +3,8 @@ import { getJSON } from '../util';
 
 export var Photon = L.Class.extend({
   options: {
-    serviceUrl: 'https://photon.komoot.de/api/',
-    reverseUrl: 'https://photon.komoot.de/reverse/',
+    serviceUrl: 'https://photon.komoot.io/api/',
+    reverseUrl: 'https://photon.komoot.io/reverse/',
     nameProperties: ['name', 'street', 'suburb', 'hamlet', 'town', 'city', 'state', 'country']
   },
 


### PR DESCRIPTION
Until October 2020 the API was available under photon.komoot.de. New url is photon.komoot.io.
Fixes reverse issue after change
Fixes https://github.com/perliedman/leaflet-control-geocoder/issues/293