### PR TITLE
Substantially improve Photon results with map-derived parameters

### DIFF
--- a/src/control.ts
+++ b/src/control.ts
@@ -316,9 +316,10 @@ export class GeocoderControl extends EventedControl {
     const event: StartGeocodeEvent = { input: value };
     this.fire(suggest ? 'startsuggest' : 'startgeocode', event);
 
+    const context = { map: this._map };
     const results = suggest
-      ? await this.options.geocoder!.suggest!(value)
-      : await this.options.geocoder!.geocode(value);
+      ? await this.options.geocoder!.suggest!(value, context)
+      : await this.options.geocoder!.geocode(value, context);
 
     if (requestCount === this._requestCount) {
       const event: FinishGeocodeEvent = { input: value, results };

--- a/src/geocoders/photon.ts
+++ b/src/geocoders/photon.ts
@@ -22,8 +22,17 @@ export class Photon implements IGeocoder {
     L.Util.setOptions(this, options);
   }
 
-  async geocode(query: string): Promise<GeocodingResult[]> {
+  async geocode(query: string, context?: { map?: L.Map }): Promise<GeocodingResult[]> {
     const params = geocodingParams(this.options, { q: query });
+    const center = context?.map?.getCenter?.();
+    if (center) {
+      params.lat = center.lat;
+      params.lon = center.lng;
+    }
+    const zoom = context?.map?.getZoom?.();
+    if (zoom) {
+      params.zoom = zoom;
+    }
     const data = await getJSON<any>(this.options.serviceUrl, params);
     return this._parseResults(data);
   }


### PR DESCRIPTION
The Photon geocoder returns poor, jarring results unless the center point and zoom of the map are included as query parameters.  Now these data are included. They are passed via the `context` argument, so other geocoders with similar optional parameters may be improved as well.