### PR TITLE
fix: bingMaps uri

### DIFF
--- a/src/geocoders/bing.ts
+++ b/src/geocoders/bing.ts
@@ -16,7 +16,7 @@ export interface BingOptions extends GeocoderOptions {}
  */
 export class Bing implements IGeocoder {
   options: BingOptions = {
-    serviceUrl: 'https://dev.virtualearth.net/REST/v1/Locations'
+    serviceUrl: 'https://dev.virtualearth.net/REST/v1/Locations/'
   };
 
   constructor(options?: Partial<BingOptions>) {


### PR DESCRIPTION
Bing's Maps uri was failing due to a character missing