### PR TITLE
mark suggest methods async

### DIFF
--- a/src/geocoders/arcgis.ts
+++ b/src/geocoders/arcgis.ts
@@ -45,7 +45,7 @@ export class ArcGis implements IGeocoder {
     });
   }
 
-  suggest(query: string): Promise<GeocodingResult[]> {
+  async suggest(query: string): Promise<GeocodingResult[]> {
     return this.geocode(query);
   }
 

--- a/src/geocoders/mapbox.ts
+++ b/src/geocoders/mapbox.ts
@@ -50,7 +50,7 @@ export class Mapbox implements IGeocoder {
     return this._parseResults(data);
   }
 
-  suggest(query: string): Promise<GeocodingResult[]> {
+  async suggest(query: string): Promise<GeocodingResult[]> {
     return this.geocode(query);
   }
 

--- a/src/geocoders/neutrino.ts
+++ b/src/geocoders/neutrino.ts
@@ -44,7 +44,7 @@ export class Neutrino implements IGeocoder {
     ];
   }
 
-  suggest(query: string): Promise<GeocodingResult[]> {
+  async suggest(query: string): Promise<GeocodingResult[]> {
     return this.geocode(query);
   }
 

--- a/src/geocoders/opencage.ts
+++ b/src/geocoders/opencage.ts
@@ -25,7 +25,7 @@ export class OpenCage implements IGeocoder {
     return this._parseResults(data);
   }
 
-  suggest(query: string): Promise<GeocodingResult[]> {
+  async suggest(query: string): Promise<GeocodingResult[]> {
     return this.geocode(query);
   }
 

--- a/src/geocoders/photon.ts
+++ b/src/geocoders/photon.ts
@@ -44,7 +44,7 @@ export class Photon implements IGeocoder {
     return this._parseResults(data);
   }
 
-  suggest(query: string): Promise<GeocodingResult[]> {
+  async suggest(query: string): Promise<GeocodingResult[]> {
     return this.geocode(query);
   }
 

--- a/src/geocoders/what3words.ts
+++ b/src/geocoders/what3words.ts
@@ -39,7 +39,7 @@ export class What3Words implements IGeocoder {
     ];
   }
 
-  suggest(query: string): Promise<GeocodingResult[]> {
+  async suggest(query: string): Promise<GeocodingResult[]> {
     return this.geocode(query);
   }
 


### PR DESCRIPTION
I noticed that these `suggest()` methods return `Promise<GeocodingResult[]>` so I've marked them as `async`.